### PR TITLE
[appletea-152] Fixed Idling socket reconnect issue, and hid API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules
 /public/bundles/homeBundle.js
 /public/bundles/roomBundle.js
+/config/config/config.js
 **/.DS_Store

--- a/app.js
+++ b/app.js
@@ -71,7 +71,7 @@ app.use('/room', express.static(path.join(__dirname, 'public')));
 // TODO: Make the secret actually secret
 require('./config/passport')(passport);
 app.use(session({ 
-  secret: 'Secret',
+  secret: configKeys.SESSION_SECRET,
   resave: false,
   saveUninitialized: false
 })); 

--- a/app.js
+++ b/app.js
@@ -34,11 +34,12 @@ require('./config/classes/AllRooms').initializeObj();
 var mongoose = require('mongoose');
 
 // configuration ===============================================================
-// RANDY's LOCAL MONGODB
-// mongoose.connect('mongodb://localhost:27017/Appletea'); 
+var configKeys = require('./config/config/config');
+
 // Mlab Testing
-// TODO: Make this secret
-mongoose.connect('mongodb://randy:123@ds019856.mlab.com:19856/appletea-db');
+mongoose.connect(configKeys.MONGOOSE_TEST);
+// mongoose.connect(configKeys.MONGOOSE_LIVE);
+// mongoose.connect(configKeys.MONGOOSE_LOCAL);
 
 var app = express();
 

--- a/config/sockets/socket.js
+++ b/config/sockets/socket.js
@@ -125,6 +125,10 @@ var startSockets = function(server) {
 
       socket.leave(socket.room);
     });
+
+    // Pings the Client to update the server whenever a user connects/reconnects to the server
+    socket.emit('From Server: Initialize room by pinging client first', 0);
+    
   });
 }
 

--- a/views/Room.jsx
+++ b/views/Room.jsx
@@ -47,9 +47,13 @@ var Room = React.createClass({
   },
 
   componentDidMount: function() {
+    socket.on('From Server: Initialize room by pinging client first', this.initializeRoomInServerWithData);
     socket.on("From Server: Update MyPlaylist with new playlists" , this.updateAllPlaylistEntries);
     socket.on("From Server: Update selected playlist", this.updateOnePlaylistEntry);
+  },
 
+  // EVENT HANDLER: Initialize room for server
+  initializeRoomInServerWithData: function() {
     socket.emit("From Client: Initialize room", {
       user: this.props.user,
       room: this.props.room


### PR DESCRIPTION
Fixed idling and socket losing connections by reinitializing the socket Room Object on the server instead of the client, also added a config to hide API keys. Currently previous git versions may show these API keys but that's okay, these are temporary API keys that would definitely not be used in actual production.